### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete string escaping or encoding

### DIFF
--- a/src/main/webapp/app/core/pkcsxx/pkcsxx.component.ts
+++ b/src/main/webapp/app/core/pkcsxx/pkcsxx.component.ts
@@ -906,8 +906,9 @@ export default class PKCSXX extends mixins(AlertMixin, Vue) {
             } else {
               subject += '/' + name.toUpperCase() + '=';
             }
-            const re = new RegExp(/\//, 'g');
-            subject += value.value.replace(re, '\\/');
+            subject += value.value
+              .replace(/\\/g, '\\\\')
+              .replace(/\//g, '\\/');
           }
         }
       }


### PR DESCRIPTION
Potential fix for [https://github.com/kuehne-trustable-de/ca3sCore/security/code-scanning/22](https://github.com/kuehne-trustable-de/ca3sCore/security/code-scanning/22)

In general, the fix is to perform escaping using a single, well-defined step that handles all relevant metacharacters, including backslashes, instead of only replacing `/`. For OpenSSL subject strings, both `/` (field separator) and `\` (escape indicator) must be treated; if we escape `/` by turning it into `\/`, we must first escape any literal backslashes so we do not create sequences that OpenSSL will interpret as escapes rather than literal characters.

The best minimal change here is to change the escaping of `value.value` from a single `replace` on `/` to a chained replacement that first doubles backslashes and then escapes slashes. This preserves current semantics for inputs without backslashes while safely handling backslashes when present. Concretely, on line 909–910, replace the `RegExp` and single `replace` with two `replace` calls:

1. `value.value.replace(/\\/g, '\\\\')` – replace each `\` with `\\`.
2. `.replace(/\//g, '\\/')` – then escape `/` as before.

No additional imports or helpers are needed; this uses built-in JavaScript `String.prototype.replace` with regular expressions.

The change is localized to `src/main/webapp/app/core/pkcsxx/pkcsxx.component.ts` inside `getOpensslCommon`, around lines 909–910, and does not modify other behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
